### PR TITLE
Fix prequant reduced-primaries ordering

### DIFF
--- a/index.html
+++ b/index.html
@@ -886,7 +886,9 @@
             // === Pre-Quantize Colors if selected ===
             let preQuantPalette = null;
             if (prequant !== "none") {
-                if (prequant.startsWith('reduced')) {
+                if (prequant === "reduced-primaries") {
+                    preQuantPalette = palettes["reduced-primaries"];
+                } else if (prequant.startsWith('reduced')) {
                     // Use your k-means quantization code here, just like before
                     let numColors = parseInt(prequant.replace('reduced', ''), 10) || 8;
                     let allColors = [];
@@ -920,8 +922,6 @@
                         }
                     }
                     preQuantPalette = clusters;
-                } else if (prequant === "reduced-primaries") {
-                    preQuantPalette = palettes["reduced-primaries"];
                 }
                 // Apply pre-quantization to image data
                 for (let i = 0; i < data.length; i += 4) {


### PR DESCRIPTION
## Summary
- ensure the predefined `reduced-primaries` palette is used before generic `reduced` handling

## Testing
- `node --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684afc4e4af4832d841d3220990404be